### PR TITLE
Add example Google Maps and file management MCP servers

### DIFF
--- a/servers/README.md
+++ b/servers/README.md
@@ -1,0 +1,16 @@
+# Example MCP Servers
+
+This directory contains two example [Model Context Protocol](https://modelcontextprotocol.io) servers that may help civil site engineers:
+
+- `google-maps-server.js` – exposes a tool for geocoding addresses using the Google Maps Geocoding API. Set the `GOOGLE_MAPS_API_KEY` environment variable before running.
+- `file-management-server.js` – provides simple tools to read and write UTF-8 text files on the local file system.
+
+Run either server with Node.js:
+
+```bash
+node servers/google-maps-server.js
+# or
+node servers/file-management-server.js
+```
+
+Both servers communicate over stdio and can be plugged into any MCP-compatible client.

--- a/servers/file-management-server.js
+++ b/servers/file-management-server.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Basic MCP server for simple local file management
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio');
+const { z } = require('zod');
+const fs = require('fs/promises');
+const path = require('path');
+
+(async () => {
+  const server = new McpServer({
+    name: 'file-management',
+    version: '1.0.0',
+    description: 'MCP server offering simple file read/write tools.'
+  });
+
+  server.registerTool('read_file', {
+    title: 'Read file',
+    description: 'Read a UTF-8 text file from disk.',
+    inputSchema: z.object({
+      path: z.string()
+    })
+  }, async ({ path: filePath }) => {
+    const absPath = path.resolve(filePath);
+    const content = await fs.readFile(absPath, 'utf-8');
+    return {
+      content: [{ type: 'text', text: content }]
+    };
+  });
+
+  server.registerTool('write_file', {
+    title: 'Write file',
+    description: 'Write UTF-8 text content to a file on disk.',
+    inputSchema: z.object({
+      path: z.string(),
+      content: z.string()
+    })
+  }, async ({ path: filePath, content }) => {
+    const absPath = path.resolve(filePath);
+    await fs.writeFile(absPath, content, 'utf-8');
+    return {
+      content: [{ type: 'text', text: `Wrote ${absPath}` }]
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+})();

--- a/servers/google-maps-server.js
+++ b/servers/google-maps-server.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Basic MCP server for Google Maps operations
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio');
+const { z } = require('zod');
+
+(async () => {
+  const server = new McpServer({
+    name: 'google-maps',
+    version: '1.0.0',
+    description: 'MCP server providing simple Google Maps capabilities.'
+  });
+
+  server.registerTool('geocode', {
+    title: 'Geocode address',
+    description: 'Convert a street address to latitude and longitude using Google Maps Geocoding API.',
+    inputSchema: z.object({
+      address: z.string()
+    })
+  }, async ({ address }) => {
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+    if (!apiKey)
+      throw new Error('GOOGLE_MAPS_API_KEY environment variable is required');
+
+    const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(address)}&key=${apiKey}`;
+    const response = await fetch(url);
+    if (!response.ok)
+      throw new Error(`Geocoding failed with status ${response.status}`);
+    const data = await response.json();
+    const location = data.results?.[0]?.geometry?.location;
+    if (!location)
+      throw new Error('No results found');
+    return {
+      content: [{ type: 'json', json: location }]
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+})();


### PR DESCRIPTION
## Summary
- add basic Google Maps MCP server with geocoding tool
- add simple file management MCP server for reading and writing files
- document example servers and how to run them

## Testing
- `npm test` *(fails: browserType.launchPersistentContext: Chromium distribution 'chrome' is not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f5fd29d4832586556315da66b593